### PR TITLE
add `cuinfo` module

### DIFF
--- a/.github/workflows/comment-bot.yml
+++ b/.github/workflows/comment-bot.yml
@@ -4,7 +4,6 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
-
 jobs:
   tag:  # /tag <tagname> <commit>
     if: startsWith(github.event.comment.body, '/tag ')
@@ -33,13 +32,10 @@ jobs:
             comment_id: context.payload.comment.id, content: "eyes"})
     - name: Tag Commit
       run: |
-        git clone https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY} repo
-        git -C repo tag $(echo "$BODY" | awk '{print $2" "$3}')
-        git -C repo push --tags
-        rm -rf repo
+        git tag $(echo "$BODY" | awk '{print $2" "$3}')
+        git push --tags
       env:
         BODY: ${{ github.event.comment.body }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: React Success
       uses: actions/github-script@v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,12 +41,12 @@ jobs:
     - run: python -m tests --cov-report=term-missing --cov-report=xml
   matlab:
     runs-on: [self-hosted, matlab]
-    name: Test matlab
+    name: Test matlab & cuda
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - run: pip install -U .[dev]
+    - run: pip install -U .[dev,cuda]
     - run: python -m tests --cov-report=term-missing --cov-report=xml
   deploy:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,9 @@ jobs:
         python-version: ${{ matrix.python }}
     - run: pip install -U .[dev]
     - run: python -m tests --cov-report=term-missing --cov-report=xml
+    - run: codecov
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   matlab:
     runs-on: [self-hosted, matlab]
     name: Test matlab & cuda
@@ -48,6 +51,9 @@ jobs:
         fetch-depth: 0
     - run: pip install -U .[dev,cuda]
     - run: python -m tests --cov-report=term-missing --cov-report=xml
+    - run: codecov
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   deploy:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     needs: [check, matlab, test]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,5 +57,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: casperdcl/deploy-pypi@v1
         with:
-           password: ${{ secrets.pypi_token }}
+           password: ${{ secrets.PYPI_TOKEN }}
            build: true
+           gpg_key: ${{ secrets.GPG_KEY }}

--- a/README.rst
+++ b/README.rst
@@ -13,13 +13,24 @@ Install
 -------
 
 Intended for inclusion in requirements for other packages.
-The package name is ``miutil``. Options include:
+The package name is ``miutil``. Extra install options include:
 
 - nii
+
+  - provides `miutil.imio.nii <https://github.com/AMYPAD/miutil/blob/master/miutil/imio/nii.py>`_
+
 - plot
+
+  - provides `miutil.plot <https://github.com/AMYPAD/miutil/blob/master/miutil/plot.py>`_
+
+    - includes a useful 3D multi-volume ``imscroll`` function which depends only on ``matplotlib``
+
 - cuda
 
-To install options and their dependencies,
+  - provides `miutil.cuinfo <https://github.com/AMYPAD/miutil/blob/master/miutil/cuinfo.py>`_
+
+
+To install extras and their dependencies,
 use the package name ``miutil[option1,option2]``.
 
 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ miutil
 
 Medical imaging utilities.
 
-|Versions| |Py-Versions| |Tests| |LICENCE|
+|Versions| |Py-Versions| |Tests| |Coverage| |LICENCE|
 
 Basic functionality needed for `AMYPAD <https://github.com/AMYPAD/AMYPAD>`_
 and `NiftyPET <https://github.com/NiftyPET/NiftyPET>`_.
@@ -36,6 +36,8 @@ use the package name ``miutil[option1,option2]``.
 
 .. |Tests| image:: https://img.shields.io/github/workflow/status/AMYPAD/miutil/Test
    :target: https://github.com/AMYPAD/miutil/actions
+.. |Coverage| image:: https://codecov.io/gh/AMYPAD/miutil/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/AMYPAD/miutil
 .. |Versions| image:: https://img.shields.io/pypi/v/miutil.svg
    :target: https://github.com/AMYPAD/miutil/releases
 .. |Py-Versions| image:: https://img.shields.io/pypi/pyversions/miutil.svg?logo=python&logoColor=white

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,7 @@ The package name is ``miutil``. Options include:
 
 - nii
 - plot
+- cuda
 
 To install options and their dependencies,
 use the package name ``miutil[option1,option2]``.

--- a/miutil/cuinfo.py
+++ b/miutil/cuinfo.py
@@ -1,0 +1,40 @@
+"""CUDA helpers
+Usage:
+  miutil.cuinfo [options]
+
+Options:
+  -f, --nvcc-flags  : print out flags for use nvcc compilation
+"""
+import pynvml
+
+__all__ = ["get_cc", "get_nvcc_flags"]
+
+
+def nvmlDeviceGetCudaComputeCapability(handle):
+    major = pynvml.c_int()
+    minor = pynvml.c_int()
+    fn = pynvml.get_func_pointer("nvmlDeviceGetCudaComputeCapability")
+    ret = fn(handle, pynvml.byref(major), pynvml.byref(minor))
+    pynvml.check_return(ret)
+    return [major.value, minor.value]
+
+
+def get_cc(dev_id=0):
+    """returns get compute capability [major, minor]"""
+    pynvml.nvmlInit()
+    handle = pynvml.nvmlDeviceGetHandleByIndex(dev_id)
+    return tuple(nvmlDeviceGetCudaComputeCapability(handle))
+
+
+def get_nvcc_flags(dev_id=0):
+    return "-gencode=arch=compute_{0:d}{1:d},code=compute_{0:d}{1:d}".format(*get_cc())
+
+
+if __name__ == "__main__":
+    from argopt import argopt
+
+    args = argopt(__doc__).parse_args()
+    if args.nvcc_flags:
+        print(get_nvcc_flags())
+    else:
+        print("Compute capability: {:d}.{:d}".format(*get_cc()))

--- a/miutil/cuinfo.py
+++ b/miutil/cuinfo.py
@@ -30,11 +30,15 @@ def get_nvcc_flags(dev_id=0):
     return "-gencode=arch=compute_{0:d}{1:d},code=compute_{0:d}{1:d}".format(*get_cc())
 
 
-if __name__ == "__main__":
+def main(*args, **kwargs):
     from argopt import argopt
 
-    args = argopt(__doc__).parse_args()
+    args = argopt(__doc__).parse_args(*args, **kwargs)
     if args.nvcc_flags:
         print(get_nvcc_flags())
     else:
         print("Compute capability: {:d}.{:d}".format(*get_cc()))
+
+
+if __name__ == "__main__":
+    main()

--- a/miutil/cuinfo.py
+++ b/miutil/cuinfo.py
@@ -3,11 +3,14 @@ Usage:
   miutil.cuinfo [options]
 
 Options:
-  -f, --nvcc-flags  : print out flags for use nvcc compilation
+  -c, --dev-count      : print number of devices (ignores `-d`)
+  -f, --nvcc-flags     : print out flags for use nvcc compilation
+  -d ID, --dev-id ID   : select device ID [default: None:int] for all
 """
+from argopt import argopt
 import pynvml
 
-__all__ = ["get_cc", "get_nvcc_flags"]
+__all__ = ["get_cc", "get_nvcc_flags", "get_device_count"]
 
 
 def nvmlDeviceGetCudaComputeCapability(handle):
@@ -19,25 +22,47 @@ def nvmlDeviceGetCudaComputeCapability(handle):
     return [major.value, minor.value]
 
 
-def get_cc(dev_id=0):
+def get_device_count():
+    pynvml.nvmlInit()
+    return pynvml.nvmlDeviceGetCount()
+
+
+def get_cc(dev_id=-1):
     """returns get compute capability [major, minor]"""
     pynvml.nvmlInit()
-    handle = pynvml.nvmlDeviceGetHandleByIndex(dev_id)
+    if dev_id < 0:
+        dev_id = get_device_count() + dev_id
+    try:
+        handle = pynvml.nvmlDeviceGetHandleByIndex(dev_id)
+    except pynvml.NVMLError:
+        raise IndexError("invalid dev_id")
     return tuple(nvmlDeviceGetCudaComputeCapability(handle))
 
 
-def get_nvcc_flags(dev_id=0):
-    return "-gencode=arch=compute_{0:d}{1:d},code=compute_{0:d}{1:d}".format(*get_cc())
+def get_nvcc_flags(dev_id=-1):
+    return "-gencode=arch=compute_{0:d}{1:d},code=compute_{0:d}{1:d}".format(
+        *get_cc(dev_id)
+    )
 
 
 def main(*args, **kwargs):
-    from argopt import argopt
-
     args = argopt(__doc__).parse_args(*args, **kwargs)
+    noargs = True
+    devices = range(get_device_count()) if args.dev_id is None else [args.dev_id]
+
+    if args.dev_count:
+        print(get_device_count())
+        noargs = False
     if args.nvcc_flags:
-        print(get_nvcc_flags())
-    else:
-        print("Compute capability: {:d}.{:d}".format(*get_cc()))
+        print(" ".join(sorted(set(map(get_nvcc_flags, devices)))[::-1]))
+        noargs = False
+    if noargs:
+        for dev_id in devices:
+            print(
+                "Device {:2d}:compute capability:{:d}.{:d}".format(
+                    dev_id, *get_cc(dev_id)
+                )
+            )
 
 
 if __name__ == "__main__":

--- a/miutil/cuinfo.py
+++ b/miutil/cuinfo.py
@@ -74,11 +74,11 @@ def main(*args, **kwargs):
     if noargs:
         for dev_id in devices:
             print(
-                "Device {:2d}:compute capability:{:d}.{:d}".format(
-                    dev_id, *compute_capability(dev_id)
+                "Device {:2d}:{}:compute capability:{:d}.{:d}".format(
+                    dev_id, name(dev_id), *compute_capability(dev_id)
                 )
             )
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/miutil/imio/nii.py
+++ b/miutil/imio/nii.py
@@ -10,7 +10,7 @@ import nibabel as nib
 import numpy as np
 
 from . import RE_NII_GZ
-from ..fdio import create_dir
+from ..fdio import create_dir, hasext
 
 RE_GZ = re.compile(r"^(.+)(\.gz)$", flags=re.I)
 log = logging.getLogger(__name__)
@@ -25,11 +25,11 @@ def file_parts(fname, regex=RE_NII_GZ):
 
 def nii_ugzip(imfile, outpath=""):
     """Uncompress *.gz file"""
-    assert imfile[-3:].lower() == ".gz"
+    assert hasext(imfile, "gz")
+    fout, ext = file_parts(imfile, RE_GZ)
     with gzip.open(imfile, "rb") as f:
         s = f.read()
     # write the uncompressed data
-    fout = imfile[:-3]
     if outpath:
         fout = os.path.join(outpath, os.path.basename(fout))
     with open(fout, "wb") as f:
@@ -141,11 +141,11 @@ def array2nii(im, A, fnii, descrip="", trnsp=None, flip=None, storage_as=None):
         'descrip':  the description given to the file
         'trsnp':    transpose/permute the dimensions.
                     In NIfTI it has to be in this order: [x,y,z,t,...])
-        'flip':     flip tupple for flipping the direction of x,y,z axes.
+        'flip':     flip tuple for flipping the direction of x,y,z axes.
                     (1: no flip, -1: flip)
         'storage_as': uses the flip and displacement as given by the following
                     NifTI dictionary, obtained using
-                    nimpa.getnii(filepath, output='all').
+                    `getnii(filepath, output='all')`.
     """
     trnsp = trnsp or ()
     flip = flip or ()

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ dev =
     pytest-cov
     pytest-timeout
     pytest-xdist
+    codecov
 nii =
     nibabel
     numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,8 @@ plot =
     matplotlib
     numpy
     scipy
+cuda =
+    pynvml
 [options.package_data]
 * = *.md, *.rst, *.m
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,7 @@ plot =
     numpy
     scipy
 cuda =
+    argopt
     pynvml
 [options.package_data]
 * = *.md, *.rst, *.m

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,8 @@ provides = miutil
 classifiers =
     Development Status :: 4 - Beta
     Intended Audience :: Developers
+    Environment :: GPU
+    Environment :: GPU :: NVIDIA CUDA
     Intended Audience :: Education
     Intended Audience :: Healthcare Industry
     Intended Audience :: Science/Research

--- a/tests/test_cuinfo.py
+++ b/tests/test_cuinfo.py
@@ -1,23 +1,43 @@
-from pytest import importorskip
+from pytest import importorskip, raises
 
 importorskip("pynvml")
+from miutil.cuinfo import get_cc, get_device_count  # NOQA: E402
 
 
 def test_get_cc():
-    from miutil.cuinfo import get_cc
-
     cc = get_cc()
     assert len(cc) == 2, cc
     assert all(isinstance(i, int) for i in cc), cc
 
 
+def test_get_device_count():
+    devices = get_device_count()
+    assert isinstance(devices, int)
+
+
 def test_cuinfo_cli(capsys):
     from miutil.cuinfo import main
 
+    main(["--dev-count"])
+    out, _ = capsys.readouterr()
+    devices = int(out)
+    assert devices >= 0
+
+    # individual dev_id
+    for dev_id in range(devices):
+        main(["--dev-id", str(dev_id)])
+        out, _ = capsys.readouterr()
+        assert len(out.split("Device ")) == devices + 1
+
+    # all dev_ids
     main()
-    out, err = capsys.readouterr()
-    assert out.startswith("Compute capability:")
+    out, _ = capsys.readouterr()
+    assert len(out.split("Device ")) == devices + 1
+
+    # dev_id one too much
+    with raises(IndexError):
+        main(["--dev-id", str(devices)])
 
     main(["--nvcc-flags"])
-    out, err = capsys.readouterr()
-    assert out.startswith("-gencode=")
+    out, _ = capsys.readouterr()
+    assert not devices or out.startswith("-gencode=")

--- a/tests/test_cuinfo.py
+++ b/tests/test_cuinfo.py
@@ -1,24 +1,24 @@
 from pytest import importorskip, raises
 
 importorskip("pynvml")
-from miutil.cuinfo import get_cc, get_device_count  # NOQA: E402
+from miutil.cuinfo import compute_capability, num_devices  # NOQA: E402
 
 
-def test_get_cc():
-    cc = get_cc()
+def test_compute_capability():
+    cc = compute_capability()
     assert len(cc) == 2, cc
     assert all(isinstance(i, int) for i in cc), cc
 
 
-def test_get_device_count():
-    devices = get_device_count()
+def test_num_devices():
+    devices = num_devices()
     assert isinstance(devices, int)
 
 
 def test_cuinfo_cli(capsys):
     from miutil.cuinfo import main
 
-    main(["--dev-count"])
+    main(["--num-devices"])
     out, _ = capsys.readouterr()
     devices = int(out)
     assert devices >= 0

--- a/tests/test_cuinfo.py
+++ b/tests/test_cuinfo.py
@@ -1,10 +1,23 @@
 from pytest import importorskip
 
+importorskip("pynvml")
+
 
 def test_get_cc():
-    importorskip("pynvml")
     from miutil.cuinfo import get_cc
 
     cc = get_cc()
     assert len(cc) == 2, cc
     assert all(isinstance(i, int) for i in cc), cc
+
+
+def test_cuinfo_cli(capsys):
+    from miutil.cuinfo import main
+
+    main()
+    out, err = capsys.readouterr()
+    assert out.startswith("Compute capability:")
+
+    main(["--nvcc-flags"])
+    out, err = capsys.readouterr()
+    assert out.startswith("-gencode=")

--- a/tests/test_cuinfo.py
+++ b/tests/test_cuinfo.py
@@ -1,0 +1,10 @@
+from pytest import importorskip
+
+
+def test_get_cc():
+    importorskip("pynvml")
+    from miutil.cuinfo import get_cc
+
+    cc = get_cc()
+    assert len(cc) == 2, cc
+    assert all(isinstance(i, int) for i in cc), cc

--- a/tests/test_fdio.py
+++ b/tests/test_fdio.py
@@ -1,0 +1,33 @@
+from os import path
+
+from miutil import fdio
+
+
+def test_create_dir(tmp_path):
+    assert not path.exists(tmp_path / "create_dir")
+    fdio.create_dir(tmp_path / "create_dir")
+    assert path.exists(tmp_path / "create_dir")
+
+
+def test_hasext():
+    for fname, ext in [
+        ("foo.bar", ".bar"),
+        ("foo.bar", "bar"),
+        ("foo.bar.baz", "baz"),
+        ("foo/bar.baz", "baz"),
+    ]:
+        assert fdio.hasext(fname, ext)
+
+    for fname, ext in [
+        ("foo.bar", "baz"),
+        ("foo.bar.baz", "bar.baz"),
+        ("foo", "foo"),
+    ]:
+        assert not fdio.hasext(fname, ext)
+
+
+def test_tmpdir(tmp_path):
+    with fdio.tmpdir() as tmpdir:
+        assert path.exists(tmpdir)
+        res = tmpdir
+    assert not path.exists(res)

--- a/tests/test_fdio.py
+++ b/tests/test_fdio.py
@@ -4,9 +4,10 @@ from miutil import fdio
 
 
 def test_create_dir(tmp_path):
-    assert not path.exists(tmp_path / "create_dir")
-    fdio.create_dir(tmp_path / "create_dir")
-    assert path.exists(tmp_path / "create_dir")
+    tmpdir = str(tmp_path / "create_dir")
+    assert not path.exists(tmpdir)
+    fdio.create_dir(tmpdir)
+    assert path.exists(tmpdir)
 
 
 def test_hasext():
@@ -26,7 +27,7 @@ def test_hasext():
         assert not fdio.hasext(fname, ext)
 
 
-def test_tmpdir(tmp_path):
+def test_tmpdir():
     with fdio.tmpdir() as tmpdir:
         assert path.exists(tmpdir)
         res = tmpdir

--- a/tests/test_imio.py
+++ b/tests/test_imio.py
@@ -2,10 +2,10 @@ from pytest import importorskip
 
 from miutil.imio import imread
 
+np = importorskip("numpy")
+
 
 def test_imread(tmp_path):
-    np = importorskip("numpy")
-
     x = np.random.randint(10, size=(9, 9))
     fname = tmp_path / "test_imread.npy"
     np.save(fname, x)
@@ -17,3 +17,13 @@ def test_imread(tmp_path):
 
     np.savez(fname, x, x)
     assert (imread(str(fname))["arr_0"] == x).all()
+
+
+def test_nii(tmp_path):
+    nii = importorskip("miutil.imio.nii")
+
+    x = np.arange(2 * 2 * 3).reshape(2, 2, 3)
+    fname = str(tmp_path / "test_nii.nii")
+    nii.array2nii(x, np.eye(4), fname, flip=(1, 1, 1))
+    nii.nii_gzip(fname)
+    assert (imread(fname + ".gz") == x).all()


### PR DESCRIPTION
- [x] add `cuinfo`
  + allows `pip install miutil[cuda] && python -m miutil.cuinfo --nvcc-flags` to print compiler flags
  + can completely replace things like https://github.com/NiftyPET/NIMPA/tree/dev2/niftypet/nimpa/dinf
- [x] add tests
- [x] add & update documentation
- [x] add test coverage reporting

test:

```bash
pip install 'git+https://github.com/AMYPAD/miutil@cuda#egg=miutil[cuda]'
python -m miutil.cuinfo --help
```