### PR TITLE
next release v0.8.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,8 +57,6 @@ jobs:
     - if: startsWith(matrix.python, '2')
       run: pytest
     - run: codecov
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   matlab:
     if: github.event_name != 'pull_request' || github.head_ref != 'devel'
     runs-on: [self-hosted, python, cuda, matlab]
@@ -72,8 +70,6 @@ jobs:
     - run: pip install -U .[dev,nii,cuda,web,mbeautify]
     - run: pytest --durations-min=1
     - run: codecov
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     - name: Post Run setup-python
       run: setup-python -p3.7 -Dr
       if: ${{ always() }}

--- a/miutil/cuinfo.py
+++ b/miutil/cuinfo.py
@@ -18,9 +18,17 @@ __all__ = ["num_devices", "compute_capability", "memory", "name", "nvcc_flags"]
 def nvmlDeviceGetCudaComputeCapability(handle):
     major = pynvml.c_int()
     minor = pynvml.c_int()
-    fn = pynvml.get_func_pointer("nvmlDeviceGetCudaComputeCapability")
+    try:  # pynvml>=11
+        get_fn = pynvml.nvml._nvmlGetFunctionPointer
+    except AttributeError:
+        get_fn = pynvml.get_func_pointer
+    fn = get_fn("nvmlDeviceGetCudaComputeCapability")
     ret = fn(handle, pynvml.byref(major), pynvml.byref(minor))
-    pynvml.check_return(ret)
+    try:  # pynvml>=11
+        check_ret = pynvml.nvml._nvmlCheckReturn
+    except AttributeError:
+        check_ret = pynvml.check_return
+    check_ret(ret)
     return [major.value, minor.value]
 
 

--- a/miutil/fdio.py
+++ b/miutil/fdio.py
@@ -69,4 +69,7 @@ def extractall(fzip, dest, desc="Extracting"):
                 (dest / i.filename).parent.mkdir(parents=True, exist_ok=True)
                 with zipf.open(i) as fi, (dest / i.filename).open(mode="wb") as fo:
                     copyfileobj(CallbackIOWrapper(pbar.update, fi), fo)
-                (dest / i.filename).chmod((i.external_attr >> 16) & 0o777)
+                mode = (i.external_attr >> 16) & 0o777
+                if mode:
+                    (dest / i.filename).chmod(mode)
+                    log.debug(oct((i.external_attr >> 16) & 0o777))

--- a/miutil/fdio.py
+++ b/miutil/fdio.py
@@ -66,5 +66,7 @@ def extractall(fzip, dest, desc="Extracting"):
             if not getattr(i, "file_size", 0):  # directory
                 zipf.extract(i, fspath(dest))
             else:
-                with zipf.open(i) as fi, open(fspath(dest / i.filename), "wb") as fo:
+                (dest / i.filename).parent.mkdir(parents=True, exist_ok=True)
+                with zipf.open(i) as fi, (dest / i.filename).open(mode="wb") as fo:
                     copyfileobj(CallbackIOWrapper(pbar.update, fi), fo)
+                (dest / i.filename).chmod((i.external_attr >> 16) & 0o777)

--- a/miutil/mlab/__init__.py
+++ b/miutil/mlab/__init__.py
@@ -1,8 +1,10 @@
 import logging
+import os
 import re
 import sys
 from ast import literal_eval
 from os import getenv, path
+from platform import system
 from subprocess import STDOUT, CalledProcessError, check_output
 from textwrap import dedent
 
@@ -16,7 +18,7 @@ except NameError:
     FileNotFoundError = OSError
 
 
-from ..fdio import tmpdir
+from ..fdio import Path, extractall, fspath, tmpdir
 
 __all__ = ["get_engine"]
 IS_WIN = any(sys.platform.startswith(i) for i in ["win32", "cygwin"])
@@ -24,6 +26,16 @@ MATLAB_RUN = "matlab -nodesktop -nosplash -nojvm".split()
 if IS_WIN:
     MATLAB_RUN += ["-wait", "-log"]
 log = logging.getLogger(__name__)
+_MCR_URL = (
+    "https://ssd.mathworks.com/supportfiles/downloads/R2020b/Release/4"
+    "/deployment_files/installer/complete/"
+)
+MCR_ARCH = {"Windows": "win64", "Linux": "glnxa64", "Darwin": "maci64"}[system()]
+MCR_URL = {
+    "Windows": _MCR_URL + "win64/MATLAB_Runtime_R2020b_Update_4_win64.zip",
+    "Linux": _MCR_URL + "glnxa64/MATLAB_Runtime_R2020b_Update_4_glnxa64.zip",
+    "Darwin": _MCR_URL + "maci64/MATLAB_Runtime_R2020b_Update_4_maci64.dmg.zip",
+}[system()]
 
 
 class VersionError(ValueError):
@@ -32,6 +44,10 @@ class VersionError(ValueError):
 
 def check_output_u8(*args, **kwargs):
     return check_output(*args, **kwargs).decode("utf-8").strip()
+
+
+def env_prefix(key, dir):
+    os.environ[key] = "%s%s%s" % (os.environ[key], os.pathsep, fspath(dir))
 
 
 @lru_cache()
@@ -69,6 +85,8 @@ install-matlab-engine-api-for-python-in-nondefault-locations.html
                   (e.g. /tmp/builddir).
                 - If installation fails due to write permissions, try appending `--user`
                   to the above command.
+
+                Alternatively, use `get_runtime()` instead of `get_engine()`.
                 """
                 ).format(
                     matlabroot=matlabroot(default="matlabroot"), exe=sys.executable
@@ -136,3 +154,56 @@ def _install_engine():
         except CalledProcessError:
             log.warning("Normal install failed. Attempting `--user` install.")
             return check_output_u8(cmd + ["--user"], cwd=src)
+
+
+@lru_cache()
+def get_runtime(cache="~/.mcr"):
+    cache = Path(cache).expanduser()
+    mcr_root = cache
+    try:
+        mcr_root = max(i for i in mcr_root.glob("v*") if i.is_dir())
+    except ValueError:
+        from miutil.web import urlopen_cached
+
+        log.info("Downloading to %s", cache)
+        with tmpdir() as td:
+            with urlopen_cached(MCR_URL, cache) as fd:
+                extractall(fd, td)
+            inst_opts = [
+                "-mode",
+                "silent",
+                "-agreeToLicense",
+                "yes",
+                "-destinationFolder",
+                fspath(mcr_root),
+            ]
+            check_output_u8(
+                [fspath(Path(td) / ("setup" if system() == "Windows" else "install"))]
+                + inst_opts
+            )
+    # bin
+    if not (mcr_root / "bin" / MCR_ARCH).is_dir():
+        log.warning("Cannot find MCR bin")
+    env_prefix("PATH", mcr_root / "bin" / MCR_ARCH)
+
+    # libs
+    env_var = {
+        "Linux": "LD_LIBRARY_PATH",
+        "Windows": "PATH",
+        "Darwin": "DYLD_LIBRARY_PATH",
+    }[system()]
+    if not (mcr_root / "runtime" / MCR_ARCH).is_dir():
+        log.warning("Cannot find MCR libs")
+    env_prefix(env_var, mcr_root / "runtime" / MCR_ARCH)
+
+    # python module
+    pydist = mcr_root / "extern" / "engines" / "python" / "dist"
+    if not pydist.is_dir():
+        log.warning("Cannot find MCR Python dist")
+    if fspath(pydist) not in sys.path:
+        sys.path.insert(1, fspath(pydist))
+
+    log.info("Installed")
+    import matlab
+
+    return matlab

--- a/miutil/mlab/__init__.py
+++ b/miutil/mlab/__init__.py
@@ -59,7 +59,10 @@ def check_output_u8(*args, **kwargs):
 
 
 def env_prefix(key, dir):
-    os.environ[key] = "%s%s%s" % (os.environ[key], os.pathsep, fspath(dir))
+    try:
+        os.environ[key] = "%s%s%s" % (os.environ[key], os.pathsep, fspath(dir))
+    except KeyError:
+        os.environ[key] = str(fspath(dir))
 
 
 @lru_cache()

--- a/miutil/mlab/__init__.py
+++ b/miutil/mlab/__init__.py
@@ -204,6 +204,5 @@ def get_runtime(cache="~/.mcr"):
         sys.path.insert(1, fspath(pydist))
 
     log.info("Installed")
-    import matlab
 
-    return matlab
+    return mcr_root

--- a/miutil/mlab/beautify.py
+++ b/miutil/mlab/beautify.py
@@ -17,7 +17,7 @@ from ..web import get_file
 from . import get_engine, lru_cache
 
 log = logging.getLogger(__name__)
-MBEAUTIFIER_REV = "9c3c82387ec3c0fb29e707ebd060e8e2ca9ea6f2"
+MBEAUTIFIER_REV = "1a57849e44662f56271dc0eefa746855698a719a"
 
 
 @lru_cache()

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,8 +7,8 @@ license=Apache 2.0
 license_file=LICENCE.md
 url=https://github.com/AMYPAD/miutil
 project_urls=
-    Changelog = https://github.com/AMYPAD/miutil/releases
-    Documentation = https://github.com/AMYPAD/miutil/#miutil
+    Changelog=https://github.com/AMYPAD/miutil/releases
+    Documentation=https://github.com/AMYPAD/miutil/#miutil
 maintainer=Casper da Costa-Luis
 maintainer_email=casper.dcl@physics.org
 keywords=fMRI, PET, SPECT, EEG, MEG
@@ -43,7 +43,7 @@ classifiers=
 setup_requires=setuptools>=42; wheel; setuptools_scm[toml]>=3.4
 install_requires=
     pathlib2; python_version <= "2.7"
-    tqdm
+    tqdm>=4.40.0
 packages=find:
 python_requires=>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*
 [options.extras_require]
@@ -56,18 +56,19 @@ dev=
     pytest-timeout
     pytest-xdist
     codecov
-nii = nibabel; numpy
-plot = matplotlib; numpy; scipy
-cuda = argopt; pynvml
-web = requests
-mbeautify = argopt; %(web)s
+nii=nibabel; numpy
+plot=matplotlib; numpy; scipy
+cuda=argopt; pynvml
+web=requests
+mbeautify=argopt; tqdm>=4.42.0; %(web)s
 [options.entry_points]
-console_scripts =
-    cuinfo = miutil.cuinfo:main
-    mbeautify = miutil.mlab.beautify:main
-
+console_scripts=
+    cuinfo=miutil.cuinfo:main
+    mbeautify=miutil.mlab.beautify:main
+[options.packages.find]
+exclude=tests
 [bdist_wheel]
-universal = 1
+universal=1
 
 [flake8]
 max_line_length=88

--- a/tests/test_mlab.py
+++ b/tests/test_mlab.py
@@ -37,9 +37,12 @@ def test_runtime():
     importorskip("miutil.web")
     from miutil.mlab import get_runtime
 
-    matlab = get_runtime()
-    matlab2 = get_runtime()
-    assert matlab == matlab2
+    mcr_root = get_runtime()
+    for i in ("bin", "extern", "mcr", "runtime", "sys", "toolbox"):
+        assert (mcr_root / i).is_dir()
+
+    mcr_root2 = get_runtime()
+    assert mcr_root == mcr_root2
 
 
 def test_beautify(eng):

--- a/tests/test_mlab.py
+++ b/tests/test_mlab.py
@@ -1,4 +1,4 @@
-from pytest import fixture, importorskip, skip
+from pytest import fixture, importorskip, mark, skip
 
 
 @fixture
@@ -30,6 +30,16 @@ def test_engine(eng):
 
     eng2 = get_engine()
     assert eng == eng2
+
+
+@mark.timeout(3600)
+def test_runtime():
+    importorskip("miutil.web")
+    from miutil.mlab import get_runtime
+
+    matlab = get_runtime()
+    matlab2 = get_runtime()
+    assert matlab == matlab2
 
 
 def test_beautify(eng):


### PR DESCRIPTION
- add `mlab.get_runtime()`
  + [x] latest version
  + [ ] SPM12 runtime compatible version (https://github.com/AMYPAD/SPM12/issues/1)
    * [x] Linux
    * [ ] Windows
    * [ ] Darwin
- update CLI
  + add `-r, --runtime`
  + add runtime `[<command>...]`
- update `MBeautifier` version
- fix dependency versions (#21)
- fix `pynvml==11` `AttributeError` (#22)
- fix `fdio.extractall()` permissions
- don't package tests (#21)

----

- fixes #21
- fixes #22